### PR TITLE
add constraints to fix ambiguous constraint warning

### DIFF
--- a/Example/TinyConstraints/Examples/Advanced.swift
+++ b/Example/TinyConstraints/Examples/Advanced.swift
@@ -19,6 +19,7 @@ class Advanced: UIView {
         addSubview(container)
         container.width(310)
         container.height(min: 310)
+        container.height(320, priority: UILayoutPriorityDefaultLow)
         container.center(in: self)
     }
     

--- a/Example/TinyConstraints/Examples/Basic.swift
+++ b/Example/TinyConstraints/Examples/Basic.swift
@@ -16,6 +16,7 @@ class Basic: UIView {
         addSubview(container)
         container.width(320)
         container.height(min: 420)
+        container.height(440, priority: UILayoutPriorityDefaultLow)
         container.center(in: self)
         
         var row = -1


### PR DESCRIPTION
There were a couple of ambiguous constraint warnings that were distracting me.

```
po [[UIWindow keyWindow] _autolayoutTrace]

•UIWindow:0x7fc260d17e50 - AMBIGUOUS LAYOUT
|   •UIView:0x7fc260f00570
|   |   *UIScrollView:0x7fc26280a400
|   |   |   *UIView:0x7fc260f09460
|   |   |   |   *constraints.Basic:0x7fc260f08830
|   |   |   |   |   *constraints.Container:0x7fc260d04590- AMBIGUOUS LAYOUT for constraints.Container:0x7fc260d04590.minY{id: 717}, constraints.Container:0x7fc260d04590.Height{id: 711}

[snip]

|   |   |   |   *constraints.Advanced:0x7fc260d15760
|   |   |   |   |   *constraints.Container:0x7fc260d15c50- AMBIGUOUS LAYOUT for constraints.Container:0x7fc260d15c50.minY{id: 787}, constraints.Container:0x7fc260d15c50.Height{id: 781}
|   |   |   |   *constraints.Collections:0x7fc260d16000
|   |   |   |   |   *constraints.Container:0x7fc260d16600
|   |   |   |   |   |   *constraints.ArrowView:0x7fc260d167a0
|   |   |   |   |   |   |   *constraints.Arrow:0x7fc260d16940
|   |   |   |   |   |   |   |   *UIView:0x7fc260d16ae0
|   |   |   |   |   |   |   |   *UIView:0x7fc260d170c0
|   |   |   |   |   |   |   |   *UIView:0x7fc260d17590
|   |   |   UIImageView:0x7fc260c086f0
|   |   *constraints.PageIndicator:0x7fc260e081b0
|   |   |   *UIView:0x7fc260e0a670
|   |   |   *UIView:0x7fc260e0c5f0
|   |   |   *UIView:0x7fc260e099e0

Legend:
	* - is laid out with auto layout
	+ - is laid out manually, but is represented in the layout engine because translatesAutoresizingMaskIntoConstraints = YES
	• - layout engine host
```

The fix is to add a low priority equal constraint for any greater/less-than constraint.

Related: As priority is just an integer, i'm using the ugly defaults from UIKit. Have you considered creating an TinyConstraints priority enum? Would be so nice to do: `container.height(320, .lowPriority)` or `container.height(320, importance: .required)`