### PR TITLE
Made references to NSLayoutConstraint more consistent in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ view.center(in: superview, offset: CGPoint(x: 10, y: 10))
 
 `Tiny Constraints` gives you convenient and tiny typealiases for handling constraints.
 
-- Constraint = NSLayoutConstraint
-- Constraints = [NSLayoutConstraint]
+- `Constraint` = `NSLayoutConstraint`
+- `Constraints` = `[NSLayoutConstraint]`
 
 ### Equal and Unequal Anchors
 This constraints the `top-anchor` of the view to the `top-anchor` of the superview.


### PR DESCRIPTION
Easier to read `NSLayoutConstraint` over NSLayoutConstraint
This change gives typealiases code formatting in the README