### PR TITLE
Add method to set origin in view

### DIFF
--- a/TinyConstraints/Classes/TinyConstraints.swift
+++ b/TinyConstraints/Classes/TinyConstraints.swift
@@ -73,6 +73,20 @@ public extension Constrainable {
         
         return constraints
     }
+
+    @discardableResult
+    public func origin(_ point: CGPoint, inView view: Constrainable, priority: ConstraintPriority = .high, isActive: Bool = true) -> Constraints {
+        let constraints = [
+                leftAnchor.constraint(equalTo: view.leftAnchor, constant: point.x).with(priority),
+                topAnchor.constraint(equalTo: view.topAnchor, constant: point.y).with(priority)
+        ]
+
+        if isActive {
+            Constraint.activate(constraints)
+        }
+
+        return constraints
+    }
     
     @discardableResult
     public func width(_ width: CGFloat, priority: ConstraintPriority = .high, isActive: Bool = true) -> Constraint {


### PR DESCRIPTION
Enables you to set top and left constraint with one line:
```
view.origin(CGPoint(x: 100.0, y: 100.0), inView: superview)
```
Instead of:
```
view.top(to: superview, offset: 100.0)
view.left(to: superview, offset: 100.0)
```

