### PR TITLE
Fixed issue with ViewControllers embedded in NavigationControllers

### DIFF
--- a/TinyConstraints/Classes/Constrainable.swift
+++ b/TinyConstraints/Classes/Constrainable.swift
@@ -26,13 +26,9 @@
     
     extension View: Constrainable {
         
-        public func prepareForLayoutIfNeeded(with view: Constrainable? = nil) {
+        public func prepareForLayoutIfNeeded() {
             
             translatesAutoresizingMaskIntoConstraints = false
-            
-            if let view = view as? NSView {
-                view.translatesAutoresizingMaskIntoConstraints = false
-            }
         }
     }
 #else
@@ -40,13 +36,9 @@
     
     extension View: Constrainable {
         
-        public func prepareForLayoutIfNeeded(with view: Constrainable? = nil) {
+        public func prepareForLayoutIfNeeded() {
             
             translatesAutoresizingMaskIntoConstraints = false
-            
-            if let view = view as? UIView {
-                view.translatesAutoresizingMaskIntoConstraints = false
-            }
         }
     }
 #endif
@@ -54,7 +46,7 @@
 
 
 extension LayoutGuide: Constrainable {
-    public func prepareForLayoutIfNeeded(with view: Constrainable?) {}
+    public func prepareForLayoutIfNeeded() {}
 }
 
 public protocol Constrainable {
@@ -71,5 +63,5 @@ public protocol Constrainable {
     var widthAnchor: NSLayoutDimension { get }
     var heightAnchor: NSLayoutDimension { get }
 
-    func prepareForLayoutIfNeeded(with view: Constrainable?)
+    func prepareForLayoutIfNeeded()
 }

--- a/TinyConstraints/Classes/TinyConstraints.swift
+++ b/TinyConstraints/Classes/TinyConstraints.swift
@@ -32,7 +32,7 @@ public extension Constrainable {
     
     @discardableResult
     public func center(in view: Constrainable, offset: CGPoint = .zero, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraints {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         let constraints = [
             centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: offset.x).with(priority),
@@ -48,7 +48,7 @@ public extension Constrainable {
     
     @discardableResult
     public func edges(to view: Constrainable, insets: EdgeInsets = .zero, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraints {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         let constraints = [
             topAnchor.constraint(equalTo: view.topAnchor, constant: insets.top).with(priority),
@@ -66,7 +66,7 @@ public extension Constrainable {
     
     @discardableResult
     public func size(_ size: CGSize, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraints {
-        prepareForLayoutIfNeeded(with: nil)
+        prepareForLayoutIfNeeded()
         
         let constraints = [
             widthAnchor.constraint(equalToConstant: size.width).with(priority),
@@ -82,7 +82,7 @@ public extension Constrainable {
     
     @discardableResult
     public func origin(to view: Constrainable, insets: CGVector = .zero, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraints {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         let constraints = [
             leftAnchor.constraint(equalTo: view.leftAnchor, constant: insets.dx).with(priority),
@@ -98,7 +98,7 @@ public extension Constrainable {
     
     @discardableResult
     public func width(_ width: CGFloat, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: nil)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return widthAnchor.constraint(equalToConstant: width).with(priority).set(active: isActive)
@@ -109,7 +109,7 @@ public extension Constrainable {
     
     @discardableResult
     public func width(to view: Constrainable, _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return widthAnchor.constraint(equalTo: dimension ?? view.widthAnchor, multiplier: multiplier, constant: offset).with(priority).set(active: isActive)
@@ -120,7 +120,7 @@ public extension Constrainable {
     
     @discardableResult
     public func width(min: CGFloat? = nil, max: CGFloat? = nil, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraints {
-        prepareForLayoutIfNeeded(with: nil)
+        prepareForLayoutIfNeeded()
         
         var constraints: Constraints = []
         
@@ -141,7 +141,7 @@ public extension Constrainable {
     
     @discardableResult
     public func height(_ height: CGFloat, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: nil)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return heightAnchor.constraint(equalToConstant: height).with(priority).set(active: isActive)
@@ -152,7 +152,7 @@ public extension Constrainable {
     
     @discardableResult
     public func height(to view: Constrainable, _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return heightAnchor.constraint(equalTo: dimension ?? view.heightAnchor, multiplier: multiplier, constant: offset).with(priority).set(active: isActive)
@@ -163,7 +163,7 @@ public extension Constrainable {
     
     @discardableResult
     public func height(min: CGFloat? = nil, max: CGFloat? = nil, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraints {
-        prepareForLayoutIfNeeded(with: nil)
+        prepareForLayoutIfNeeded()
         
         var constraints: Constraints = []
         
@@ -184,13 +184,13 @@ public extension Constrainable {
     
     @discardableResult
     public func leadingToTrailing(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         return leading(to: view, view.trailingAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func leading(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return leadingAnchor.constraint(equalTo: anchor ?? view.leadingAnchor, constant: offset).with(priority).set(active: isActive)
@@ -201,13 +201,13 @@ public extension Constrainable {
     
     @discardableResult
     public func leftToRight(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         return left(to: view, view.rightAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func left(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return leftAnchor.constraint(equalTo: anchor ?? view.leftAnchor, constant: offset).with(priority).set(active: isActive)
@@ -218,13 +218,13 @@ public extension Constrainable {
     
     @discardableResult
     public func trailingToLeading(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         return trailing(to: view, view.leadingAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func trailing(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return trailingAnchor.constraint(equalTo: anchor ?? view.trailingAnchor, constant: offset).with(priority).set(active: isActive)
@@ -235,13 +235,13 @@ public extension Constrainable {
     
     @discardableResult
     public func rightToLeft(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         return right(to: view, view.leftAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func right(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return rightAnchor.constraint(equalTo: anchor ?? view.rightAnchor, constant: offset).with(priority).set(active: isActive)
@@ -252,13 +252,13 @@ public extension Constrainable {
     
     @discardableResult
     public func topToBottom(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         return top(to: view, view.bottomAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func top(to view: Constrainable, _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return topAnchor.constraint(equalTo: anchor ?? view.topAnchor, constant: offset).with(priority).set(active: isActive)
@@ -269,13 +269,13 @@ public extension Constrainable {
     
     @discardableResult
     public func bottomToTop(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         return bottom(to: view, view.topAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func bottom(to view: Constrainable, _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         switch relation {
         case .equal: return bottomAnchor.constraint(equalTo: anchor ?? view.bottomAnchor, constant: offset).with(priority).set(active: isActive)
@@ -286,7 +286,7 @@ public extension Constrainable {
     
     @discardableResult
     public func centerX(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         let constraint = centerXAnchor.constraint(equalTo: anchor ?? view.centerXAnchor, constant: offset).with(priority)
         constraint.isActive = isActive
@@ -295,7 +295,7 @@ public extension Constrainable {
     
     @discardableResult
     public func centerY(to view: Constrainable, _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, priority: ConstraintPriority = .required, isActive: Bool = true) -> Constraint {
-        prepareForLayoutIfNeeded(with: view)
+        prepareForLayoutIfNeeded()
         
         let constraint = centerYAnchor.constraint(equalTo: anchor ?? view.centerYAnchor, constant: offset).with(priority)
         constraint.isActive = isActive


### PR DESCRIPTION
I found out firsthand that if you create a constraint based on a ViewController's view and that ViewController is embedded in a NavigationController then having the view's translatesAutoresizingMaskIntoConstraints set to false caused issues. I have provided screenshots so you can see what I am talking about. Removing this code seemed to fix everything based on my tests. All constraints should work properly once created.
![nonav](https://cloud.githubusercontent.com/assets/22629536/25316683/d55b5d68-2839-11e7-95f3-568c4c38da2c.jpg)
![withnav](https://cloud.githubusercontent.com/assets/22629536/25316688/eae64d78-2839-11e7-9bdf-7bc487b58fd2.jpg)



