### PR TITLE
safeAreaLayoutGuide used for iOS 11 and tvOS 11

### DIFF
--- a/TinyConstraints/Classes/TinyConstraints+superview.swift
+++ b/TinyConstraints/Classes/TinyConstraints+superview.swift
@@ -135,11 +135,14 @@ public extension View {
     }
     
     private func getConstrainable(from view: View) -> Constrainable {
-        if #available(iOS 11, tvOS 11, *) {
-            return view.safeAreaLayoutGuide
-        } else {
-            return view
-        }
+        
+        #if os(iOS) || os(tvOS)
+            if #available(iOS 11, tvOS 11, *) {
+                return view.safeAreaLayoutGuide
+            }
+        #endif
+        
+        return view
     }
     
     @discardableResult

--- a/TinyConstraints/Classes/TinyConstraints+superview.swift
+++ b/TinyConstraints/Classes/TinyConstraints+superview.swift
@@ -97,11 +97,12 @@
         @discardableResult
         public func leadingToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
             guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
+            let constrainable = getConstrainable(from: superview)
             
             if effectiveUserInterfaceLayoutDirection == .rightToLeft {
-                return leading(to: superview, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
+                return leading(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
             } else {
-                return leading(to: superview, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+                return leading(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
             }
         }
         
@@ -110,11 +111,12 @@
         @discardableResult
         public func trailingToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
             guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
+            let constrainable = getConstrainable(from: superview)
             
             if effectiveUserInterfaceLayoutDirection == .rightToLeft {
-                return trailing(to: superview, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+                return trailing(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
             } else {
-                return trailing(to: superview, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
+                return trailing(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
             }
         }
     }
@@ -132,70 +134,88 @@ public extension View {
         case none
     }
     
+    private func getConstrainable(from view: View) -> Constrainable {
+        if #available(iOS 11, tvOS 11, *) {
+            return view.safeAreaLayoutGuide
+        } else {
+            return view
+        }
+    }
     
     @discardableResult
     public func centerInSuperview(offset: CGPoint = .zero, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraints {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return center(in: superview, offset: offset, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return center(in: constrainable, offset: offset, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func edgesToSuperview(insets: TinyEdgeInsets = .zero, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraints {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return edges(to: superview, insets: insets, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return edges(to: constrainable, insets: insets, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func originToSuperview(insets: CGVector = .zero, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraints {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return origin(to: superview, insets: insets, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return origin(to: constrainable, insets: insets, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func widthToSuperview( _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return width(to: superview, dimension, multiplier: multiplier, offset: offset, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return width(to: constrainable, dimension, multiplier: multiplier, offset: offset, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func heightToSuperview( _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return height(to: superview, dimension, multiplier: multiplier, offset: offset, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return height(to: constrainable, dimension, multiplier: multiplier, offset: offset, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func leftToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return left(to: superview, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return left(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func rightToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return right(to: superview, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return right(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func topToSuperview( _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return top(to: superview, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return top(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func bottomToSuperview( _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return bottom(to: superview, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return bottom(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func centerXToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return centerX(to: superview, anchor, offset: offset, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return centerX(to: constrainable, anchor, offset: offset, priority: priority, isActive: isActive)
     }
     
     @discardableResult
     public func centerYToSuperview( _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         guard let superview = superview else { fatalError("Unable to create this constraint to it's superview, because it has no superview.") }
-        return centerY(to: superview, anchor, offset: offset, priority: priority, isActive: isActive)
+        let constrainable = getConstrainable(from: superview)
+        return centerY(to: constrainable, anchor, offset: offset, priority: priority, isActive: isActive)
     }
 }


### PR DESCRIPTION
I have added a check to the superview methods to see if the device is on iOS 11 or tvOS 11 and use the superview.safeAreaLayoutGuide, otherwise just use the superview as before. I have tested this and it works. It is backwards compatible and should not break any existing code.

Here are pictures to demonstrate the effect: 
Before: ![before](https://user-images.githubusercontent.com/22629536/31252570-9978967a-a9ef-11e7-9b21-5630e98bc1c1.png) After: ![after](https://user-images.githubusercontent.com/22629536/31252638-c2708de4-a9ef-11e7-92d8-00a493dffec2.png)

