### PR TITLE
adds override classes

### DIFF
--- a/TinyConstraints.xcodeproj/project.pbxproj
+++ b/TinyConstraints.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		2DD9870F1E4DBB6A002F80D6 /* Constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD9870A1E4DBB6A002F80D6 /* Constraints.swift */; };
 		2DD987101E4DBB6A002F80D6 /* Stack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD9870B1E4DBB6A002F80D6 /* Stack.swift */; };
 		2DD987111E4DBB6A002F80D6 /* TinyConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD9870C1E4DBB6A002F80D6 /* TinyConstraints.swift */; };
+		6337505D218E2C0F003224BE /* TinyConstraints+override.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6337505B218E2C0F003224BE /* TinyConstraints+override.swift */; };
+		6337505E218E2C0F003224BE /* TinyConstraints+superview+override.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6337505C218E2C0F003224BE /* TinyConstraints+superview+override.swift */; };
 		A932CB751F78081B00401861 /* TinyConstraints+superview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A932CB741F78081B00401861 /* TinyConstraints+superview.swift */; };
 		A97552CE2128478300C1EC7E /* TinyEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97552CD2128478300C1EC7E /* TinyEdgeInsets.swift */; };
 		A9D467D11E6777CA00C331FA /* Abstraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D467D01E6777CA00C331FA /* Abstraction.swift */; };
@@ -25,6 +27,8 @@
 		2DD9870A1E4DBB6A002F80D6 /* Constraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constraints.swift; sourceTree = "<group>"; };
 		2DD9870B1E4DBB6A002F80D6 /* Stack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stack.swift; sourceTree = "<group>"; };
 		2DD9870C1E4DBB6A002F80D6 /* TinyConstraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TinyConstraints.swift; sourceTree = "<group>"; };
+		6337505B218E2C0F003224BE /* TinyConstraints+override.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TinyConstraints+override.swift"; sourceTree = "<group>"; };
+		6337505C218E2C0F003224BE /* TinyConstraints+superview+override.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TinyConstraints+superview+override.swift"; sourceTree = "<group>"; };
 		90CB57961FB3C77700379457 /* Universal-Framework-Target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Universal-Framework-Target.xcconfig"; sourceTree = "<group>"; };
 		90CB57981FB3C77700379457 /* Universal-Target-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Universal-Target-Base.xcconfig"; sourceTree = "<group>"; };
 		A932CB741F78081B00401861 /* TinyConstraints+superview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TinyConstraints+superview.swift"; sourceTree = "<group>"; };
@@ -73,6 +77,8 @@
 		2DD987081E4DBB6A002F80D6 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				6337505B218E2C0F003224BE /* TinyConstraints+override.swift */,
+				6337505C218E2C0F003224BE /* TinyConstraints+superview+override.swift */,
 				A9D467D01E6777CA00C331FA /* Abstraction.swift */,
 				2DD7AA431E599FD800509EBC /* Constrainable.swift */,
 				2DD9870A1E4DBB6A002F80D6 /* Constraints.swift */,
@@ -173,6 +179,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6337505D218E2C0F003224BE /* TinyConstraints+override.swift in Sources */,
 				A97552CE2128478300C1EC7E /* TinyEdgeInsets.swift in Sources */,
 				2DD987111E4DBB6A002F80D6 /* TinyConstraints.swift in Sources */,
 				A932CB751F78081B00401861 /* TinyConstraints+superview.swift in Sources */,
@@ -180,6 +187,7 @@
 				2DD9870F1E4DBB6A002F80D6 /* Constraints.swift in Sources */,
 				2DD7AA441E599FD800509EBC /* Constrainable.swift in Sources */,
 				A9D467D11E6777CA00C331FA /* Abstraction.swift in Sources */,
+				6337505E218E2C0F003224BE /* TinyConstraints+superview+override.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TinyConstraints/Classes/TinyConstraints+override.swift
+++ b/TinyConstraints/Classes/TinyConstraints+override.swift
@@ -1,0 +1,295 @@
+//
+//    MIT License
+//
+//    Copyright (c) 2017 Robert-Hein Hooijmans <rh.hooijmans@gmail.com>
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in
+//    all copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//    THE SOFTWARE.
+//
+
+import Foundation
+
+#if os(OSX)
+import AppKit
+#else
+import UIKit
+#endif
+
+@available(iOS 10.0, *)
+public extension Constrainable {
+
+    private func excludeConstraintIfExists<T: AnyObject>(withAnchor anchor: NSLayoutAnchor<T>, to view: Constrainable? = nil, withAnchor secondViewAnchor: NSLayoutAnchor<T>? = nil) {
+        guard let selfView = self as? View,
+            let view = view as? View else {
+            return
+        }
+
+        if let constraint = view.constraints.first(where: { constraint -> Bool in
+            let matchingItems = (constraint.firstItem as? View) == selfView && (constraint.secondItem as? View) == view
+            let mathingAnchors = constraint.firstAnchor == anchor && constraint.secondAnchor == secondViewAnchor
+            return matchingItems && mathingAnchors
+        }) {
+            view.removeConstraint(constraint)
+        }
+    }
+
+    @discardableResult
+    public func center(in view: Constrainable, offset: CGPoint = .zero, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraints {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: centerXAnchor, to: view, withAnchor: view.centerXAnchor)
+            excludeConstraintIfExists(withAnchor: centerYAnchor, to: view, withAnchor: view.centerYAnchor)
+        }
+
+        return center(in: view, offset: offset, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func edges(to view: Constrainable, excluding excludedEdge: LayoutEdge = .none, insets: TinyEdgeInsets = .zero, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraints {
+        if shouldOverride {
+            if !excludedEdge.contains(.top) {
+                excludeConstraintIfExists(withAnchor: topAnchor, to: view, withAnchor: view.topAnchor)
+            }
+
+            if !excludedEdge.contains(.left) {
+                excludeConstraintIfExists(withAnchor: leftAnchor, to: view, withAnchor: view.leftAnchor)
+            }
+
+            if !excludedEdge.contains(.bottom) {
+                excludeConstraintIfExists(withAnchor: bottomAnchor, to: view, withAnchor: view.bottomAnchor)
+            }
+
+            if !excludedEdge.contains(.right) {
+                excludeConstraintIfExists(withAnchor: rightAnchor, to: view, withAnchor: view.rightAnchor)
+            }
+        }
+
+        return edges(to: view, excluding: excludedEdge, insets: insets, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func size(_ size: CGSize, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraints {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: widthAnchor)
+            excludeConstraintIfExists(withAnchor: heightAnchor)
+        }
+
+        return self.size(size, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func size(to view: Constrainable, multiplier: CGFloat = 1, offset: CGFloat = 0, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraints {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: widthAnchor, to: view, withAnchor: view.widthAnchor)
+            excludeConstraintIfExists(withAnchor: heightAnchor, to: view, withAnchor: view.heightAnchor)
+        }
+        
+        return self.size(to: view, multiplier: multiplier, offset: offset, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func origin(to view: Constrainable, insets: CGVector = .zero, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraints {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: leftAnchor, to: view, withAnchor: view.leftAnchor)
+            excludeConstraintIfExists(withAnchor: topAnchor, to: view, withAnchor: view.topAnchor)
+        }
+        
+        return origin(to: view, insets: insets, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func width(_ width: CGFloat, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: widthAnchor)
+        }
+        
+        return self.width(width, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func width(to view: Constrainable, _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: widthAnchor, to: view, withAnchor: view.widthAnchor)
+        }
+        
+        return self.width(to: view, dimension, multiplier: multiplier, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func widthToHeight(of view: Constrainable, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: widthAnchor, to: view, withAnchor: view.heightAnchor)
+        }
+        
+        return widthToHeight(of: view, multiplier: multiplier, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func width(min: CGFloat? = nil, max: CGFloat? = nil, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraints {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: widthAnchor)
+        }
+        
+        return self.width(min: min, max: max, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func height(_ height: CGFloat, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: heightAnchor)
+        }
+        
+        return self.height(height, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func height(to view: Constrainable, _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: heightAnchor, to: view, withAnchor: view.heightAnchor)
+        }
+        
+        return self.height(to: view, dimension, multiplier: multiplier, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func heightToWidth(of view: Constrainable, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: heightAnchor)
+        }
+        
+        return heightToWidth(of: view, multiplier: multiplier, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func height(min: CGFloat? = nil, max: CGFloat? = nil, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraints {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: heightAnchor)
+        }
+        
+        return self.height(min: min, max: max, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func aspectRatio(_ ratio: CGFloat, relation: ConstraintRelation = .equal, priotity: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        return widthToHeight(of: self, multiplier: ratio, offset: 0, relation: relation, priority: priotity, isActive: isActive, shouldOverride: shouldOverride)
+    }
+
+    @discardableResult
+    public func leadingToTrailing(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        prepareForLayout()
+        return leading(to: view, view.trailingAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+
+    @discardableResult
+    public func leading(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: leadingAnchor, to: view, withAnchor: view.leadingAnchor)
+        }
+        
+        return leading(to: view, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func leftToRight(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        prepareForLayout()
+        return left(to: view, view.rightAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+
+    @discardableResult
+    public func left(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: leftAnchor, to: view, withAnchor: anchor ?? view.leftAnchor)
+        }
+        
+        return left(to: view, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func trailingToLeading(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        return trailing(to: view, view.leadingAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+
+    @discardableResult
+    public func trailing(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: trailingAnchor, to: view, withAnchor: anchor ?? view.trailingAnchor)
+        }
+        
+        return trailing(to: view, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func rightToLeft(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        return right(to: view, view.leftAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+
+    @discardableResult
+    public func right(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: rightAnchor, to: view, withAnchor: anchor ?? view.rightAnchor)
+        }
+        
+        return right(to: view, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func topToBottom(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        return top(to: view, view.bottomAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+
+    @discardableResult
+    public func top(to view: Constrainable, _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: topAnchor, to: view, withAnchor: anchor ?? view.topAnchor)
+        }
+        
+        return top(to: view, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func bottomToTop(of view: Constrainable, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        return bottom(to: view, view.topAnchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+
+    @discardableResult
+    public func bottom(to view: Constrainable, _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: bottomAnchor, to: view, withAnchor: anchor ?? view.bottomAnchor)
+        }
+        
+        return bottom(to: view, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func centerX(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: centerXAnchor, to: view, withAnchor: anchor ?? view.centerXAnchor)
+        }
+        
+        return centerX(to: view, anchor, offset: offset, priority: priority, isActive: isActive)
+    }
+
+    @discardableResult
+    public func centerY(to view: Constrainable, _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, priority: LayoutPriority = .required, isActive: Bool = true, shouldOverride: Bool = false) -> Constraint {
+        if shouldOverride {
+            excludeConstraintIfExists(withAnchor: centerYAnchor, to: view, withAnchor: anchor ?? view.centerYAnchor)
+        }
+        
+        return centerY(to: view, anchor, offset: offset, priority: priority, isActive: isActive)
+    }
+
+}

--- a/TinyConstraints/Classes/TinyConstraints+superview+override.swift
+++ b/TinyConstraints/Classes/TinyConstraints+superview+override.swift
@@ -1,0 +1,235 @@
+//
+//    MIT License
+//
+//    Copyright (c) 2017 Robert-Hein Hooijmans <rh.hooijmans@gmail.com>
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in
+//    all copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//    THE SOFTWARE.
+//
+
+#if os(OSX)
+import AppKit
+
+@available(tvOS 10.0, *)
+@available(iOS 10.0, *)
+public extension View {
+    
+    @discardableResult
+    func edgesToSuperview(excluding excludedEdge: LayoutEdge = .none, insets: TinyEdgeInsets = .zero, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraints {
+        var constraints = Constraints()
+        
+        if !excludedEdge.contains(.top) {
+            constraints.append(topToSuperview(offset: insets.top, usingSafeArea: usingSafeArea))
+        }
+        
+        if !excludedEdge.contains(.left) {
+            constraints.append(leftToSuperview(offset: insets.left, usingSafeArea: usingSafeArea))
+        }
+        
+        if !excludedEdge.contains(.right) {
+            constraints.append(rightToSuperview(offset: -insets.right, usingSafeArea: usingSafeArea))
+        }
+        
+        if !excludedEdge.contains(.bottom) {
+            constraints.append(bottomToSuperview(offset: -insets.bottom, usingSafeArea: usingSafeArea))
+        }
+        
+        return constraints
+    }
+}
+#else
+import UIKit
+
+@available(tvOS 10.0, *)
+@available(iOS 10.0, *)
+public extension View {
+    
+    @discardableResult
+    func edgesToSuperview(excluding excludedEdge: LayoutEdge = .none, insets: TinyEdgeInsets = .zero, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraints {
+        var constraints = Constraints()
+        
+        if !excludedEdge.contains(.top) {
+            constraints.append(topToSuperview(offset: insets.top, usingSafeArea: usingSafeArea))
+        }
+        
+        if effectiveUserInterfaceLayoutDirection == .leftToRight {
+            
+            if !(excludedEdge.contains(.leading) || excludedEdge.contains(.left)) {
+                constraints.append(leftToSuperview(offset: insets.left, usingSafeArea: usingSafeArea))
+            }
+            
+            if !(excludedEdge.contains(.trailing) || excludedEdge.contains(.right)) {
+                constraints.append(rightToSuperview(offset: -insets.right, usingSafeArea: usingSafeArea))
+            }
+        } else {
+            
+            if !(excludedEdge.contains(.leading) || excludedEdge.contains(.right)) {
+                constraints.append(rightToSuperview(offset: -insets.right, usingSafeArea: usingSafeArea))
+            }
+            
+            if !(excludedEdge.contains(.trailing) || excludedEdge.contains(.left)) {
+                constraints.append(leftToSuperview(offset: insets.left, usingSafeArea: usingSafeArea))
+            }
+        }
+        
+        if !excludedEdge.contains(.bottom) {
+            constraints.append(bottomToSuperview(offset: -insets.bottom, usingSafeArea: usingSafeArea))
+        }
+        
+        return constraints
+    }
+    
+    @discardableResult
+    public func leadingToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        
+        if effectiveUserInterfaceLayoutDirection == .rightToLeft {
+            return leading(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+        } else {
+            return leading(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+        }
+    }
+    
+    @discardableResult
+    public func trailingToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        
+        if effectiveUserInterfaceLayoutDirection == .rightToLeft {
+            return trailing(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+        } else {
+            return trailing(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+        }
+    }
+    
+    @discardableResult
+    func horizontalToSuperview(insets: TinyEdgeInsets = .zero, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraints {
+        
+        var constraints = Constraints()
+        
+        if effectiveUserInterfaceLayoutDirection == .leftToRight {
+            constraints.append(leftToSuperview(offset: insets.left, usingSafeArea: usingSafeArea))
+            constraints.append(rightToSuperview(offset: -insets.right, usingSafeArea: usingSafeArea))
+        } else {
+            constraints.append(rightToSuperview(offset: -insets.right, usingSafeArea: usingSafeArea))
+            constraints.append(leftToSuperview(offset: insets.left, usingSafeArea: usingSafeArea))
+        }
+        
+        return constraints
+    }
+    
+    @discardableResult
+    func verticalToSuperview(insets: TinyEdgeInsets = .zero, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraints {
+        
+        let constraints = Constraints(arrayLiteral:
+            topToSuperview(offset: insets.top, usingSafeArea: usingSafeArea),
+                                      bottomToSuperview(offset: -insets.bottom, usingSafeArea: usingSafeArea)
+        )
+        return constraints
+    }
+}
+#endif
+
+@available(tvOS 10.0, *)
+@available(iOS 10.0, *)
+public extension View {
+    
+    private func safeConstrainable(for superview: View?, usingSafeArea: Bool) -> Constrainable {
+        guard let superview = superview else {
+            fatalError("Unable to create this constraint to it's superview, because it has no superview.")
+        }
+        
+        prepareForLayout()
+        
+        #if os(iOS) || os(tvOS)
+        if #available(iOS 11, tvOS 11, *){
+            if usingSafeArea {
+                return superview.safeAreaLayoutGuide
+            }
+        }
+        #endif
+        
+        return superview
+    }
+    
+    
+    @discardableResult
+    public func centerInSuperview(offset: CGPoint = .zero, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraints {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return center(in: constrainable, offset: offset, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func edgesToSuperview(insets: TinyEdgeInsets = .zero, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraints {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return edges(to: constrainable, insets: insets, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func originToSuperview(insets: CGVector = .zero, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraints {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return origin(to: constrainable, insets: insets, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func widthToSuperview( _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return width(to: constrainable, dimension, multiplier: multiplier, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func heightToSuperview( _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return height(to: constrainable, dimension, multiplier: multiplier, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func leftToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return left(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func rightToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return right(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func topToSuperview( _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return top(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func bottomToSuperview( _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return bottom(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func centerXToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return centerX(to: constrainable, anchor, offset: offset, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+    
+    @discardableResult
+    public func centerYToSuperview( _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false, shouldOverride: Bool = false) -> Constraint {
+        let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
+        return centerY(to: constrainable, anchor, offset: offset, priority: priority, isActive: isActive, shouldOverride: shouldOverride)
+    }
+}


### PR DESCRIPTION
Hi @roberthein.
First of all, congratulations for you library, it's amazing.

### Description & Motivation
I've created an override behaviour based on my scenario necessities, which basically removes, if existent, a constraint with the same anchors that the one that you are trying to add.
So basically, if you set `myView.topToSuperview()` and lately, you set 'myView.topToSuperview(offset: 10)', in the way how the library work nowadays, it create two constraints to superview, one with offset 0 and the other with offset 10, which creates an inconsistence in the layout. I've added this override behaviour to avoid this kind of situation.

### Implementation Details
I've basically added two extra classes, which uses the same arguments of the existing `TinyConstraints` and `TinyConstraints+superview` classes adding `shouldOverride` argument.

For example, you can use
`myView.topToSuperview(offset: 10, shouldOverride: true)`.

All created functions has the same behaviour: If `shouldOverride == true`, check if exists a constraint with the same purpose - same anchors - that the one that is being added and delete it before creating this new constraint.

If it's possible, would appreciate your opinion about this feature. Thanks in advance.