### PR TITLE
🧹 Remove redundant switch cases.

### DIFF
--- a/TinyConstraints.xcodeproj/project.pbxproj
+++ b/TinyConstraints.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A932CB751F78081B00401861 /* TinyConstraints+superview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A932CB741F78081B00401861 /* TinyConstraints+superview.swift */; };
 		A97552CE2128478300C1EC7E /* TinyEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97552CD2128478300C1EC7E /* TinyEdgeInsets.swift */; };
 		A9D467D11E6777CA00C331FA /* Abstraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D467D01E6777CA00C331FA /* Abstraction.swift */; };
+		C0ED0A912357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0ED0A902357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		A932CB741F78081B00401861 /* TinyConstraints+superview.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TinyConstraints+superview.swift"; sourceTree = "<group>"; };
 		A97552CD2128478300C1EC7E /* TinyEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TinyEdgeInsets.swift; sourceTree = "<group>"; };
 		A9D467D01E6777CA00C331FA /* Abstraction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Abstraction.swift; sourceTree = "<group>"; };
+		C0ED0A902357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutDimension+ConstraintRelation.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 				2DD9870C1E4DBB6A002F80D6 /* TinyConstraints.swift */,
 				A932CB741F78081B00401861 /* TinyConstraints+superview.swift */,
 				A97552CD2128478300C1EC7E /* TinyEdgeInsets.swift */,
+				C0ED0A902357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -174,6 +177,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C0ED0A912357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift in Sources */,
 				A97552CE2128478300C1EC7E /* TinyEdgeInsets.swift in Sources */,
 				2DD987111E4DBB6A002F80D6 /* TinyConstraints.swift in Sources */,
 				A932CB751F78081B00401861 /* TinyConstraints+superview.swift in Sources */,

--- a/TinyConstraints.xcodeproj/project.pbxproj
+++ b/TinyConstraints.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		A97552CE2128478300C1EC7E /* TinyEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97552CD2128478300C1EC7E /* TinyEdgeInsets.swift */; };
 		A9D467D11E6777CA00C331FA /* Abstraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D467D01E6777CA00C331FA /* Abstraction.swift */; };
 		C0ED0A912357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0ED0A902357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift */; };
+		C0ED0A93235742E400A20B2B /* NSLayoutAxisAnchor+ConstraintRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0ED0A92235742E400A20B2B /* NSLayoutAxisAnchor+ConstraintRelation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
 		A97552CD2128478300C1EC7E /* TinyEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TinyEdgeInsets.swift; sourceTree = "<group>"; };
 		A9D467D01E6777CA00C331FA /* Abstraction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Abstraction.swift; sourceTree = "<group>"; };
 		C0ED0A902357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutDimension+ConstraintRelation.swift"; sourceTree = "<group>"; };
+		C0ED0A92235742E400A20B2B /* NSLayoutAxisAnchor+ConstraintRelation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutAxisAnchor+ConstraintRelation.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 				A932CB741F78081B00401861 /* TinyConstraints+superview.swift */,
 				A97552CD2128478300C1EC7E /* TinyEdgeInsets.swift */,
 				C0ED0A902357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift */,
+				C0ED0A92235742E400A20B2B /* NSLayoutAxisAnchor+ConstraintRelation.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -180,6 +183,7 @@
 				C0ED0A912357405000A20B2B /* NSLayoutDimension+ConstraintRelation.swift in Sources */,
 				A97552CE2128478300C1EC7E /* TinyEdgeInsets.swift in Sources */,
 				2DD987111E4DBB6A002F80D6 /* TinyConstraints.swift in Sources */,
+				C0ED0A93235742E400A20B2B /* NSLayoutAxisAnchor+ConstraintRelation.swift in Sources */,
 				A932CB751F78081B00401861 /* TinyConstraints+superview.swift in Sources */,
 				2DD987101E4DBB6A002F80D6 /* Stack.swift in Sources */,
 				2DD9870F1E4DBB6A002F80D6 /* Constraints.swift in Sources */,

--- a/TinyConstraints/Classes/Abstraction.swift
+++ b/TinyConstraints/Classes/Abstraction.swift
@@ -45,4 +45,3 @@ import Foundation
     
     public typealias TinyEdgeInsets = UIEdgeInsets
 #endif
-

--- a/TinyConstraints/Classes/Constraints.swift
+++ b/TinyConstraints/Classes/Constraints.swift
@@ -81,4 +81,3 @@ public extension Constraint {
         }
 }
 #endif
-

--- a/TinyConstraints/Classes/NSLayoutAxisAnchor+ConstraintRelation.swift
+++ b/TinyConstraints/Classes/NSLayoutAxisAnchor+ConstraintRelation.swift
@@ -1,0 +1,49 @@
+//
+//  NSLayoutAxisAnchor+ConstraintRelation.swift
+//  TinyConstraints
+//
+//  Created by Joan Disho on 16.10.19.
+//  Copyright © 2019 Robert-Hein Hooijmans. All rights reserved.
+//
+
+import Foundation
+
+#if os(OSX)
+    import AppKit
+#else
+    import UIKit
+#endif
+
+internal extension NSLayoutXAxisAnchor {
+
+    func constraint(
+        to anchor: NSLayoutXAxisAnchor,
+        relation: ConstraintRelation
+        ) -> NSLayoutConstraint {
+        switch relation {
+        case .equal:
+            return constraint(equalTo: anchor)
+        case .equalOrLess:
+            return constraint(lessThanOrEqualTo: anchor)
+        case .equalOrGreater:
+            return constraint(greaterThanOrEqualTo: anchor)
+        }
+    }
+}
+
+internal extension NSLayoutYAxisAnchor {
+
+    func constraint(
+        to anchor: NSLayoutYAxisAnchor,
+        relation: ConstraintRelation
+        ) -> NSLayoutConstraint {
+        switch relation {
+        case .equal:
+            return constraint(equalTo: anchor)
+        case .equalOrLess:
+            return constraint(lessThanOrEqualTo: anchor)
+        case .equalOrGreater:
+            return constraint(greaterThanOrEqualTo: anchor)
+        }
+    }
+}

--- a/TinyConstraints/Classes/NSLayoutAxisAnchor+ConstraintRelation.swift
+++ b/TinyConstraints/Classes/NSLayoutAxisAnchor+ConstraintRelation.swift
@@ -15,35 +15,21 @@ import Foundation
 #endif
 
 internal extension NSLayoutXAxisAnchor {
-
-    func constraint(
-        to anchor: NSLayoutXAxisAnchor,
-        relation: ConstraintRelation
-        ) -> NSLayoutConstraint {
+    func constraint(to anchor: NSLayoutXAxisAnchor, relation: ConstraintRelation) -> NSLayoutConstraint {
         switch relation {
-        case .equal:
-            return constraint(equalTo: anchor)
-        case .equalOrLess:
-            return constraint(lessThanOrEqualTo: anchor)
-        case .equalOrGreater:
-            return constraint(greaterThanOrEqualTo: anchor)
+        case .equal: return constraint(equalTo: anchor)
+        case .equalOrLess: return constraint(lessThanOrEqualTo: anchor)
+        case .equalOrGreater: return constraint(greaterThanOrEqualTo: anchor)
         }
     }
 }
 
 internal extension NSLayoutYAxisAnchor {
-
-    func constraint(
-        to anchor: NSLayoutYAxisAnchor,
-        relation: ConstraintRelation
-        ) -> NSLayoutConstraint {
+    func constraint(to anchor: NSLayoutYAxisAnchor, relation: ConstraintRelation) -> NSLayoutConstraint {
         switch relation {
-        case .equal:
-            return constraint(equalTo: anchor)
-        case .equalOrLess:
-            return constraint(lessThanOrEqualTo: anchor)
-        case .equalOrGreater:
-            return constraint(greaterThanOrEqualTo: anchor)
+        case .equal: return constraint(equalTo: anchor)
+        case .equalOrLess: return constraint(lessThanOrEqualTo: anchor)
+        case .equalOrGreater: return constraint(greaterThanOrEqualTo: anchor)
         }
     }
 }

--- a/TinyConstraints/Classes/NSLayoutDimension+ConstraintRelation.swift
+++ b/TinyConstraints/Classes/NSLayoutDimension+ConstraintRelation.swift
@@ -19,21 +19,22 @@ internal extension NSLayoutDimension {
     func constraint(
         to dimension: NSLayoutDimension,
         multiplier: CGFloat,
-        relation: ConstraintRelation = .equal
+        offset: CGFloat,
+        relation: ConstraintRelation
         ) -> NSLayoutConstraint {
         switch relation {
         case .equal:
-            return constraint(equalTo: dimension, multiplier: multiplier)
+            return constraint(equalTo: dimension, multiplier: multiplier, constant: offset)
         case .equalOrLess:
-            return constraint(lessThanOrEqualTo: dimension, multiplier: multiplier)
+            return constraint(lessThanOrEqualTo: dimension, multiplier: multiplier, constant: offset)
         case .equalOrGreater:
-            return constraint(greaterThanOrEqualTo: dimension, multiplier: multiplier)
+            return constraint(greaterThanOrEqualTo: dimension, multiplier: multiplier, constant: offset)
         }
     }
 
     func constraint(
         toConstant constant: CGFloat,
-        relation: ConstraintRelation = .equal
+        relation: ConstraintRelation
         ) -> NSLayoutConstraint {
         switch relation {
         case .equal:

--- a/TinyConstraints/Classes/NSLayoutDimension+ConstraintRelation.swift
+++ b/TinyConstraints/Classes/NSLayoutDimension+ConstraintRelation.swift
@@ -15,37 +15,19 @@ import Foundation
 #endif
 
 internal extension NSLayoutDimension {
-
-    func constraint(
-        to dimension: NSLayoutDimension,
-        multiplier: CGFloat,
-        offset: CGFloat,
-        relation: ConstraintRelation
-        ) -> NSLayoutConstraint {
+    func constraint(to dimension: NSLayoutDimension, multiplier: CGFloat, offset: CGFloat, relation: ConstraintRelation) -> NSLayoutConstraint {
         switch relation {
-        case .equal:
-            return constraint(equalTo: dimension, multiplier: multiplier, constant: offset)
-        case .equalOrLess:
-            return constraint(lessThanOrEqualTo: dimension, multiplier: multiplier, constant: offset)
-        case .equalOrGreater:
-            return constraint(greaterThanOrEqualTo: dimension, multiplier: multiplier, constant: offset)
+        case .equal: return constraint(equalTo: dimension, multiplier: multiplier, constant: offset)
+        case .equalOrLess: return constraint(lessThanOrEqualTo: dimension, multiplier: multiplier, constant: offset)
+        case .equalOrGreater: return constraint(greaterThanOrEqualTo: dimension, multiplier: multiplier, constant: offset)
         }
     }
 
-    func constraint(
-        toConstant constant: CGFloat,
-        relation: ConstraintRelation
-        ) -> NSLayoutConstraint {
+    func constraint(toConstant constant: CGFloat, relation: ConstraintRelation) -> NSLayoutConstraint {
         switch relation {
-        case .equal:
-            return constraint(equalToConstant: constant)
-        case .equalOrLess:
-            return constraint(lessThanOrEqualToConstant: constant)
-        case .equalOrGreater:
-            return constraint(greaterThanOrEqualToConstant: constant)
+        case .equal: return constraint(equalToConstant: constant)
+        case .equalOrLess: return constraint(lessThanOrEqualToConstant: constant)
+        case .equalOrGreater: return constraint(greaterThanOrEqualToConstant: constant)
         }
     }
 }
-
-
-

--- a/TinyConstraints/Classes/NSLayoutDimension+ConstraintRelation.swift
+++ b/TinyConstraints/Classes/NSLayoutDimension+ConstraintRelation.swift
@@ -1,0 +1,50 @@
+//
+//  NSLayoutDimension+ConstraintRelation.swift
+//  TinyConstraints
+//
+//  Created by Joan Disho on 16.10.19.
+//  Copyright © 2019 Robert-Hein Hooijmans. All rights reserved.
+//
+
+import Foundation
+
+#if os(OSX)
+    import AppKit
+#else
+    import UIKit
+#endif
+
+internal extension NSLayoutDimension {
+
+    func constraint(
+        to dimension: NSLayoutDimension,
+        multiplier: CGFloat,
+        relation: ConstraintRelation = .equal
+        ) -> NSLayoutConstraint {
+        switch relation {
+        case .equal:
+            return constraint(equalTo: dimension, multiplier: multiplier)
+        case .equalOrLess:
+            return constraint(lessThanOrEqualTo: dimension, multiplier: multiplier)
+        case .equalOrGreater:
+            return constraint(greaterThanOrEqualTo: dimension, multiplier: multiplier)
+        }
+    }
+
+    func constraint(
+        toConstant constant: CGFloat,
+        relation: ConstraintRelation = .equal
+        ) -> NSLayoutConstraint {
+        switch relation {
+        case .equal:
+            return constraint(equalToConstant: constant)
+        case .equalOrLess:
+            return constraint(lessThanOrEqualToConstant: constant)
+        case .equalOrGreater:
+            return constraint(greaterThanOrEqualToConstant: constant)
+        }
+    }
+}
+
+
+

--- a/TinyConstraints/Classes/TinyConstraints.swift
+++ b/TinyConstraints/Classes/TinyConstraints.swift
@@ -203,12 +203,7 @@ public extension Constrainable {
     @discardableResult
     func leading(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return leadingAnchor.constraint(equalTo: anchor ?? view.leadingAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrLess: return leadingAnchor.constraint(lessThanOrEqualTo: anchor ?? view.leadingAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrGreater: return leadingAnchor.constraint(greaterThanOrEqualTo: anchor ?? view.leadingAnchor, constant: offset).with(priority).set(isActive)
-        }
+        return leadingAnchor.constraint(to: anchor ?? view.leadingAnchor, relation: relation).with(priority).set(isActive)
     }
     
     @discardableResult
@@ -220,12 +215,7 @@ public extension Constrainable {
     @discardableResult
     func left(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return leftAnchor.constraint(equalTo: anchor ?? view.leftAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrLess: return leftAnchor.constraint(lessThanOrEqualTo: anchor ?? view.leftAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrGreater: return leftAnchor.constraint(greaterThanOrEqualTo: anchor ?? view.leftAnchor, constant: offset).with(priority).set(isActive)
-        }
+        return leftAnchor.constraint(to: anchor ?? view.leftAnchor, relation: relation).with(priority).set(isActive)
     }
     
     @discardableResult
@@ -237,12 +227,7 @@ public extension Constrainable {
     @discardableResult
     func trailing(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return trailingAnchor.constraint(equalTo: anchor ?? view.trailingAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrLess: return trailingAnchor.constraint(lessThanOrEqualTo: anchor ?? view.trailingAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrGreater: return trailingAnchor.constraint(greaterThanOrEqualTo: anchor ?? view.trailingAnchor, constant: offset).with(priority).set(isActive)
-        }
+        return trailingAnchor.constraint(to: anchor ?? view.trailingAnchor, relation: relation).with(priority).set(isActive)
     }
     
     @discardableResult
@@ -254,12 +239,7 @@ public extension Constrainable {
     @discardableResult
     func right(to view: Constrainable, _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return rightAnchor.constraint(equalTo: anchor ?? view.rightAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrLess: return rightAnchor.constraint(lessThanOrEqualTo: anchor ?? view.rightAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrGreater: return rightAnchor.constraint(greaterThanOrEqualTo: anchor ?? view.rightAnchor, constant: offset).with(priority).set(isActive)
-        }
+        return rightAnchor.constraint(to: anchor ?? view.rightAnchor, relation: relation).with(priority).set(isActive)
     }
     
     @discardableResult
@@ -271,12 +251,7 @@ public extension Constrainable {
     @discardableResult
     func top(to view: Constrainable, _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return topAnchor.constraint(equalTo: anchor ?? view.topAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrLess: return topAnchor.constraint(lessThanOrEqualTo: anchor ?? view.topAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrGreater: return topAnchor.constraint(greaterThanOrEqualTo: anchor ?? view.topAnchor, constant: offset).with(priority).set(isActive)
-        }
+        return topAnchor.constraint(to: anchor ?? view.topAnchor, relation: relation).with(priority).set(isActive)
     }
     
     @discardableResult
@@ -288,12 +263,7 @@ public extension Constrainable {
     @discardableResult
     func bottom(to view: Constrainable, _ anchor: NSLayoutYAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return bottomAnchor.constraint(equalTo: anchor ?? view.bottomAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrLess: return bottomAnchor.constraint(lessThanOrEqualTo: anchor ?? view.bottomAnchor, constant: offset).with(priority).set(isActive)
-        case .equalOrGreater: return bottomAnchor.constraint(greaterThanOrEqualTo: anchor ?? view.bottomAnchor, constant: offset).with(priority).set(isActive)
-        }
+        return bottomAnchor.constraint(to: anchor ?? view.bottomAnchor, relation: relation).with(priority).set(isActive)
     }
     
     @discardableResult

--- a/TinyConstraints/Classes/TinyConstraints.swift
+++ b/TinyConstraints/Classes/TinyConstraints.swift
@@ -160,7 +160,7 @@ public extension Constrainable {
     @discardableResult
     func height(to view: Constrainable, _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        return heightAnchor.constraint(to: dimension ?? view.heightAnchor, multiplier: multiplier, relation: relation).with(priority).set(isActive)
+        return heightAnchor.constraint(to: dimension ?? view.heightAnchor, multiplier: multiplier, offset: offset, relation: relation).with(priority).set(isActive)
     }
 
     @discardableResult

--- a/TinyConstraints/Classes/TinyConstraints.swift
+++ b/TinyConstraints/Classes/TinyConstraints.swift
@@ -106,23 +106,13 @@ public extension Constrainable {
     @discardableResult
     func width(_ width: CGFloat, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return widthAnchor.constraint(equalToConstant: width).with(priority).set(isActive)
-        case .equalOrLess: return widthAnchor.constraint(lessThanOrEqualToConstant: width).with(priority).set(isActive)
-        case .equalOrGreater: return widthAnchor.constraint(greaterThanOrEqualToConstant: width).with(priority).set(isActive)
-        }
+        return widthAnchor.constraint(toConstant: width, relation: relation).with(priority).set(isActive)
     }
     
     @discardableResult
     func width(to view: Constrainable, _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return widthAnchor.constraint(equalTo: dimension ?? view.widthAnchor, multiplier: multiplier, constant: offset).with(priority).set(isActive)
-        case .equalOrLess: return widthAnchor.constraint(lessThanOrEqualTo: dimension ?? view.widthAnchor, multiplier: multiplier, constant: offset).with(priority).set(isActive)
-        case .equalOrGreater: return widthAnchor.constraint(greaterThanOrEqualTo: dimension ?? view.widthAnchor, multiplier: multiplier, constant: offset).with(priority).set(isActive)
-        }
+        return widthAnchor.constraint(to: dimension ?? view.widthAnchor, multiplier: multiplier, offset: offset, relation: relation).with(priority).set(isActive)
     }
 
     @discardableResult

--- a/TinyConstraints/Classes/TinyConstraints.swift
+++ b/TinyConstraints/Classes/TinyConstraints.swift
@@ -154,23 +154,13 @@ public extension Constrainable {
     @discardableResult
     func height(_ height: CGFloat, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return heightAnchor.constraint(equalToConstant: height).with(priority).set(isActive)
-        case .equalOrLess: return heightAnchor.constraint(lessThanOrEqualToConstant: height).with(priority).set(isActive)
-        case .equalOrGreater: return heightAnchor.constraint(greaterThanOrEqualToConstant: height).with(priority).set(isActive)
-        }
+        return heightAnchor.constraint(toConstant: height, relation: relation).with(priority).set(isActive)
     }
     
     @discardableResult
     func height(to view: Constrainable, _ dimension: NSLayoutDimension? = nil, multiplier: CGFloat = 1, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true) -> Constraint {
         prepareForLayout()
-        
-        switch relation {
-        case .equal: return heightAnchor.constraint(equalTo: dimension ?? view.heightAnchor, multiplier: multiplier, constant: offset).with(priority).set(isActive)
-        case .equalOrLess: return heightAnchor.constraint(lessThanOrEqualTo: dimension ?? view.heightAnchor, multiplier: multiplier, constant: offset).with(priority).set(isActive)
-        case .equalOrGreater: return heightAnchor.constraint(greaterThanOrEqualTo: dimension ?? view.heightAnchor, multiplier: multiplier, constant: offset).with(priority).set(isActive)
-        }
+        return heightAnchor.constraint(to: dimension ?? view.heightAnchor, multiplier: multiplier, relation: relation).with(priority).set(isActive)
     }
 
     @discardableResult


### PR DESCRIPTION
In this PR, I created extensions around `NSLayoutConstraints`, `NSLayoutXAxisAnchor`, `NSLayoutYAxisAnchor` to replace the redundant `ConstraintRelation` switches  implemented in `TinyConstraints.swift`.  