### PR TITLE
Do not make any modification to offset with respect to layout direction, which fixes #95

### DIFF
--- a/TinyConstraints/Classes/TinyConstraints+superview.swift
+++ b/TinyConstraints/Classes/TinyConstraints+superview.swift
@@ -97,12 +97,8 @@
         @discardableResult
         func leadingToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false) -> Constraint {
             let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
-            
-            if effectiveUserInterfaceLayoutDirection == .rightToLeft {
-                return leading(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
-            } else {
-                return leading(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
-            }
+
+            return leading(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
         }
         
         @available(tvOS 10.0, *)
@@ -110,12 +106,8 @@
         @discardableResult
         func trailingToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false) -> Constraint {
             let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
-            
-            if effectiveUserInterfaceLayoutDirection == .rightToLeft {
-                return trailing(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
-            } else {
-                return trailing(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
-            }
+
+            return trailing(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
         }
         
         @available(tvOS 10.0, *)


### PR DESCRIPTION
To solve issue described in #95, I suggest we should not do any special modification inside `leadingToSuperview` and `trailingToSuperview` methods. Let these methods follow the linear equation as described in [Apple Documentation](https://developer.apple.com/documentation/uikit/nslayoutconstraint):
`item1.attribute1 = multiplier × item2.attribute2 + constant`