### PR TITLE
[Del] VALID_ARCHS

### DIFF
--- a/Configurations/Universal-Target-Base.xcconfig
+++ b/Configurations/Universal-Target-Base.xcconfig
@@ -1,9 +1,4 @@
 SUPPORTED_PLATFORMS                    = macosx iphonesimulator iphoneos appletvos appletvsimulator
-VALID_ARCHS[sdk=macosx*]               = i386 x86_64
-VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
-VALID_ARCHS[sdk=appletv*]              = arm64
-VALID_ARCHS[sdk=appletvsimulator*]     = x86_64
 
 // Dynamic linking uses different default copy paths
 LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]           = $(inherited) '@executable_path/../Frameworks' '@loader_path/../Frameworks'

--- a/Example/Cartfile
+++ b/Example/Cartfile
@@ -1,1 +1,1 @@
-github "roberthein/TinyConstraints"
+github "dank-1/TinyConstraints"

--- a/Example/Cartfile.resolved
+++ b/Example/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "roberthein/TinyConstraints" "4.0.1"
+github "dank-1/TinyConstraints" "4.0.1"


### PR DESCRIPTION
Delete VALID_ARCHS from User-Defined

```
Could not find module 'TinyConstraints' for target 'arm64-apple-ios-simulator'; found: i386, x86_64-apple-ios-simulator, x86_64, i386-apple-ios-simulator
```
<img width="856" alt="スクリーンショット 2021-08-11 18 40 43" src="https://user-images.githubusercontent.com/4786597/129007074-06217812-a921-4946-81f1-5615005e6fdc.png">
