### PR TITLE
add a 'dynamic library' product to swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
         .macOS(.v10_11), .iOS(.v9), .tvOS(.v9)
     ],
     products: [
-        .library(name: "TinyConstraints", targets: ["TinyConstraints"])
+        .library(name: "TinyConstraints", targets: ["TinyConstraints"]),
+        .library(name: "TinyConstraintsDynamic", type: .dynamic, targets: ["TinyConstraints"])
     ],
     targets: [
         .target(


### PR DESCRIPTION
Hello!

I have a project with mulitple frameworks and many of the frameworks use TinyConstraints via Carthage. When trying to migrate to SPM, I bumped into an issue where it always embeds the library in every module, resulting in issues when trying to archive the app and sending to the App Store.

```
ERROR ITMS-90685: "CFBundleIdentifier Collision. There is more than one bundle with the CFBundleIdentifier value 'TinyConstraints' under the iOS application '<MyApp>.app'."
ERROR ITMS-90205: "Invalid Bundle. The bundle at '<MyApp>.app/Frameworks/<MyFramework>.framework' contains disallowed nested bundles."
ERROR ITMS-90206: "Invalid Bundle. The bundle at '<MyApp>.app/Frameworks/<MyFramework>.framework' contains disallowed file 'Frameworks'."
```

To solve that I added another product that forces the library to be dynamic. With a dynamic library I have the option to not embed the library in my modules, only in the app target, which solves my problem.