### PR TITLE
remove VALID_ARCHS (deprecated since XCode 12 i think)

### DIFF
--- a/Configurations/Universal-Target-Base.xcconfig
+++ b/Configurations/Universal-Target-Base.xcconfig
@@ -1,9 +1,4 @@
 SUPPORTED_PLATFORMS                    = macosx iphonesimulator iphoneos appletvos appletvsimulator
-VALID_ARCHS[sdk=macosx*]               = i386 x86_64
-VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
-VALID_ARCHS[sdk=appletv*]              = arm64
-VALID_ARCHS[sdk=appletvsimulator*]     = x86_64
 
 // Dynamic linking uses different default copy paths
 LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]           = $(inherited) '@executable_path/../Frameworks' '@loader_path/../Frameworks'


### PR DESCRIPTION
I was unable to run in an x86_64 simulator until removing this build setting.

https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes
> The Build Settings editor no longer includes the Valid Architectures build setting (VALID_ARCHS), and its use is discouraged. Instead, there is a new Excluded Architectures build setting (EXCLUDED_ARCHS). If a project includes VALID_ARCHS, the setting is displayed in the User-Defined section of the Build Settings editor. (15145028)