### PR TITLE
Fixed rightToLeft languages's problem

### DIFF
--- a/TinyConstraints/Classes/TinyConstraints+superview.swift
+++ b/TinyConstraints/Classes/TinyConstraints+superview.swift
@@ -65,12 +65,20 @@
                 constraints.append(topToSuperview(offset: insets.top, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
             }
             
-            if !(excludedEdge.contains(.leading) || excludedEdge.contains(.left)) {
+            if !excludedEdge.contains(.left) {
+                constraints.append(leftToSuperview(offset: insets.left, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
+            }
+            
+            if !excludedEdge.contains(.leading) {
                 constraints.append(leadingToSuperview(offset: insets.left, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
             }
                 
-            if !(excludedEdge.contains(.trailing) || excludedEdge.contains(.right)) {
+            if !excludedEdge.contains(.trailing) {
                 constraints.append(trailingToSuperview(offset: insets.right, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
+            }
+            
+            if !excludedEdge.contains(.right) {
+                constraints.append(rightToSuperview(offset: insets.right, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
             }
             
             if !excludedEdge.contains(.bottom) {

--- a/TinyConstraints/Classes/TinyConstraints+superview.swift
+++ b/TinyConstraints/Classes/TinyConstraints+superview.swift
@@ -65,24 +65,12 @@
                 constraints.append(topToSuperview(offset: insets.top, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
             }
             
-            if effectiveUserInterfaceLayoutDirection == .leftToRight {
+            if !(excludedEdge.contains(.leading) || excludedEdge.contains(.left)) {
+                constraints.append(leadingToSuperview(offset: insets.left, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
+            }
                 
-                if !(excludedEdge.contains(.leading) || excludedEdge.contains(.left)) {
-                    constraints.append(leftToSuperview(offset: insets.left, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
-                }
-                
-                if !(excludedEdge.contains(.trailing) || excludedEdge.contains(.right)) {
-                    constraints.append(rightToSuperview(offset: -insets.right, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
-                }
-            } else {
-                
-                if !(excludedEdge.contains(.leading) || excludedEdge.contains(.right)) {
-                    constraints.append(rightToSuperview(offset: -insets.right, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
-                }
-                
-                if !(excludedEdge.contains(.trailing) || excludedEdge.contains(.left)) {
-                    constraints.append(leftToSuperview(offset: insets.left, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
-                }
+            if !(excludedEdge.contains(.trailing) || excludedEdge.contains(.right)) {
+                constraints.append(trailingToSuperview(offset: insets.right, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
             }
             
             if !excludedEdge.contains(.bottom) {
@@ -98,11 +86,7 @@
         func leadingToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false) -> Constraint {
             let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
             
-            if effectiveUserInterfaceLayoutDirection == .rightToLeft {
-                return leading(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
-            } else {
-                return leading(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
-            }
+            return leading(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
         }
         
         @available(tvOS 10.0, *)
@@ -111,11 +95,7 @@
         func trailingToSuperview( _ anchor: NSLayoutXAxisAnchor? = nil, offset: CGFloat = 0, relation: ConstraintRelation = .equal, priority: LayoutPriority = .required, isActive: Bool = true, usingSafeArea: Bool = false) -> Constraint {
             let constrainable = safeConstrainable(for: superview, usingSafeArea: usingSafeArea)
             
-            if effectiveUserInterfaceLayoutDirection == .rightToLeft {
-                return trailing(to: constrainable, anchor, offset: offset, relation: relation, priority: priority, isActive: isActive)
-            } else {
-                return trailing(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
-            }
+            return trailing(to: constrainable, anchor, offset: -offset, relation: relation, priority: priority, isActive: isActive)
         }
         
         @available(tvOS 10.0, *)
@@ -125,13 +105,8 @@
             
             var constraints = Constraints()
             
-            if effectiveUserInterfaceLayoutDirection == .leftToRight {
-                constraints.append(leftToSuperview(offset: insets.left, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
-                constraints.append(rightToSuperview(offset: -insets.right, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
-            } else {
-                constraints.append(rightToSuperview(offset: -insets.right, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
-                constraints.append(leftToSuperview(offset: insets.left, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
-            }
+            constraints.append(leadingToSuperview(offset: insets.left, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
+            constraints.append(trailingToSuperview(offset: insets.right, relation: relation, priority: priority, isActive: isActive, usingSafeArea: usingSafeArea))
             
             return constraints
         }


### PR DESCRIPTION
Hi 

LeftAnchor and rightAnchor have been using in edgesToSuperView, i replaced them with leading and trailing.

If you use leftAnchor that means this view will not move to right for the rightToLeftLanguages.

https://www.hackingwithswift.com/example-code/uikit/whats-the-difference-between-leading-trailing-left-and-right-anchors

Related to https://github.com/roberthein/TinyConstraints/issues/95

Here some screen shots

![LeftToRight](https://github.com/roberthein/TinyConstraints/assets/12018061/9b52b47d-89b8-4489-a6b2-7ab7dab46b60)

![RightToLeft](https://github.com/roberthein/TinyConstraints/assets/12018061/eedce7be-aa88-44c1-9df3-9b0136d9912e)

